### PR TITLE
index: link to paper PDF on jpathinformatics.org

### DIFF
--- a/index.md
+++ b/index.md
@@ -144,7 +144,7 @@ Adam Goode, Benjamin Gilbert, Jan Harkes, Drazen Jukic, M. Satyanarayanan
 Journal of Pathology Informatics 2013, 4:27  
 [Abstract][paper-abstract]
 [HTML][paper-html]
-[PDF][paper-pdf]
+[Get PDF][paper-pdf]
 
 There is also an older technical report:
 
@@ -157,7 +157,7 @@ Computer Science Department, Carnegie Mellon University
 
 [paper-abstract]: https://www.jpathinformatics.org/article.asp?issn=2153-3539;year=2013;volume=4;issue=1;spage=27;epage=27;aulast=Goode;type=0
 [paper-html]: https://www.jpathinformatics.org/article.asp?issn=2153-3539;year=2013;volume=4;issue=1;spage=27;epage=27;aulast=Goode
-[paper-pdf]: http://download.openslide.org/docs/JPatholInform_2013_4_1_27_119005.pdf
+[paper-pdf]: https://www.jpathinformatics.org/downloadpdf.asp?issn=2153-3539;year=2013;volume=4;issue=1;spage=27;epage=27;aulast=Goode;type=2
 [tr-abstract]: http://reports-archive.adm.cs.cmu.edu/anon/2008/abstracts/08-136.html
 [tr-full]: http://reports-archive.adm.cs.cmu.edu/anon/2008/CMU-CS-08-136.pdf
 


### PR DESCRIPTION
We've been rehosting the PDF on `download.openslide.org` because `jpathinformatics.org` requires clicking through a landing page.  However, the PDF is the last user of `download.openslide.org`, and it'd be nice to fully deprecate that service, which is HTTP-only.  We could rehost the PDF in this repo (it's 1.8 MB), but instead take the path of least resistance and link to the official site.