### PR TITLE
debugopts: document `sql` debug option

### DIFF
--- a/docs/debugopts/index.md
+++ b/docs/debugopts/index.md
@@ -23,6 +23,9 @@ options supported by your copy.
 `performance`
 : Log conditions causing OpenSlide to exhibit suboptimal performance.
 
+`sql`
+: Log SQL queries performed by the SQLite decoder.
+
 `synthetic`
 : Opening the empty filename with `openslide_open("")` opens a synthetic
   test slide that exercises all image decoders.


### PR DESCRIPTION
Added in https://github.com/openslide/openslide/pull/373.