### PR TITLE
docs: document new flags for DICOM format

### DIFF
--- a/docs/debugopts/index.md
+++ b/docs/debugopts/index.md
@@ -23,6 +23,10 @@ options supported by your copy.
 `performance`
 : Log conditions causing OpenSlide to exhibit suboptimal performance.
 
+`search`
+: For formats that require searching the filesystem for related files,
+  log each skipped file and the reason for skipping it.
+
 `sql`
 : Log SQL queries performed by the SQLite decoder.
 

--- a/docs/testsuite/index.md
+++ b/docs/testsuite/index.md
@@ -117,8 +117,8 @@ original slide (e.g., if OpenSlide falls back to `generic-tiff`), change
 `vendor` to the new string or `null` for NULL.
 
 If the test should only be run if particular OpenSlide dependencies are
-available, set `requires` to a list of feature flags.  Currently there are
-no defined feature flags.
+available, set `requires` to a list of feature flags.  Currently the only
+defined feature flag is `dicom`.
 
 Pack the test:
 


### PR DESCRIPTION
The test suite added a `dicom` feature flag, and OpenSlide gained a `search` debug option.