### PR TITLE
download: support EL8 and above

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -86,7 +86,7 @@ If you're looking for the bleeding edge,
     <tr>
       <th>Linux</th>
       <th>
-        <a href="https://www.redhat.com/products/enterprise-linux/">Red Hat Enterprise Linux</a><br>
+        <a href="https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux">Red Hat Enterprise Linux</a><br>
         <a href="https://www.centos.org/centos-stream/">CentOS Stream</a>
       </th>
       <td>

--- a/download/index.md
+++ b/download/index.md
@@ -87,13 +87,12 @@ If you're looking for the bleeding edge,
       <th>Linux</th>
       <th>
         <a href="https://www.redhat.com/products/enterprise-linux/">Red Hat Enterprise Linux</a><br>
-        <a href="https://www.centos.org/">CentOS</a><br>
-        <a href="https://www.scientificlinux.org/">Scientific Linux</a>
+        <a href="https://www.centos.org/centos-stream/">CentOS Stream</a>
       </th>
       <td>
         <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>
         <code>yum install openslide</code><br>
-        <i>(RHEL/CentOS/Scientific Linux &ge; 7)</i>
+        <i>(RHEL/CentOS Stream &ge; 8)</i>
       </td>
       <td>
         <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>


### PR DESCRIPTION
OpenSlide 4.0.0 will not support EL7.  Drop Scientific Linux, which only has EL7, and update the "CentOS" references to "CentOS Stream".