### PR TITLE
synctiles: use default rendering intent from slide ICC profile

### DIFF
--- a/demo/_synctiles.py
+++ b/demo/_synctiles.py
@@ -59,7 +59,6 @@ QUALITY = 75
 TILE_SIZE = 510
 OVERLAP = 1
 LIMIT_BOUNDS = True
-RENDERING_INTENT = ImageCms.Intent.ABSOLUTE_COLORIMETRIC
 GROUP_NAME_MAP = {
     'Generic-TIFF': 'Generic TIFF',
     'Hamamatsu': 'Hamamatsu NDPI',
@@ -103,8 +102,9 @@ def get_transform(image):
     """Return a function that transforms an image to sRGB in place."""
     if image.color_profile is None:
         return lambda img: None
+    intent = ImageCms.getDefaultIntent(image.color_profile)
     transform = ImageCms.buildTransform(
-        image.color_profile, SRGB_PROFILE, 'RGB', 'RGB', RENDERING_INTENT, 0
+        image.color_profile, SRGB_PROFILE, 'RGB', 'RGB', intent, 0
     )
     def xfrm(img):
         ImageCms.applyTransform(img, transform, True)

--- a/demo/_synctiles.py
+++ b/demo/_synctiles.py
@@ -65,6 +65,7 @@ GROUP_NAME_MAP = {
     'Hamamatsu': 'Hamamatsu NDPI',
     'Hamamatsu-vms': 'Hamamatsu VMS',
     'Mirax': 'MIRAX',
+    'Philips-TIFF': 'Philips TIFF',
 }
 BUCKET_STATIC = {
     'robots.txt': {


### PR DESCRIPTION
ICC profiles don't necessarily support all rendering intents, and aren't necessarily optimized for all the intents they do support.  They can also be queried for the rendering intent recommended by the profile creator.  Use that instead of absolute colorimetric.

While we're here, add a friendly name for Philips TIFF.

xref https://github.com/openslide/openslide-python/pull/227