### PR TITLE
Add Copr and clean up package installation on Fedora/EL

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,6 +1,7 @@
 [news]: /news/
 [download]: /download/
 [download-windows]: /download/#windows-binaries
+[download-copr]: https://copr.fedorainfracloud.org/coprs/g/openslide/openslide/
 [download-ppa]: https://launchpad.net/~openslide/+archive/ubuntu/openslide
 [download-pypi]: https://pypi.org/project/openslide-python/#files
 [license]: /license/

--- a/_includes/news.md
+++ b/_includes/news.md
@@ -1,5 +1,12 @@
 {% include links.md %}
 
+## Fedora and Enterprise Linux Copr now available, 2023-10-11
+
+OpenSlide now provides a [Fedora Copr][download-copr], enabling Fedora
+and RHEL-compatible Enterprise Linux users to easily install the latest
+OpenSlide and OpenSlide Python releases before they reach Fedora or EPEL.
+
+
 ## OpenSlide version 4.0.0, 2023-10-11
 
 OpenSlide 4.0.0 adds support for DICOM WSI slides, ICC color profiles, tile

--- a/download/index.md
+++ b/download/index.md
@@ -75,11 +75,11 @@ If you're looking for the bleeding edge,
       </th>
       <td>
         <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>
-        <code>yum install openslide</code><br>
+        <code>dnf install openslide</code><br>
       </td>
       <td>
         <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>
-        <code>yum install python3-openslide</code><br>
+        <code>dnf install python3-openslide</code><br>
       </td>
     </tr>
     <tr>

--- a/download/index.md
+++ b/download/index.md
@@ -74,12 +74,36 @@ If you're looking for the bleeding edge,
         <a href="https://rockylinux.org/">Rocky Linux</a>
       </th>
       <td>
-        <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>
-        <code>dnf install openslide-tools</code><br>
+        <div>
+          <i>Official packages:</i><br>
+          <b><i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i></b><br>
+          <code>dnf install openslide-tools</code><br>
+        </div>
+        <div>
+          <i>Latest OpenSlide:</i><br>
+          <b><i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i></b><br>
+          <code>
+            dnf install dnf-plugins-core<br>
+            dnf copr enable <a href="https://copr.fedorainfracloud.org/coprs/g/openslide/openslide/">@openslide/openslide</a><br>
+            dnf install openslide-tools
+          </code>
+        </div>
       </td>
       <td>
-        <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>
-        <code>dnf install python3-openslide</code><br>
+        <div>
+          <i>Official packages:</i><br>
+          <b><i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i></b><br>
+          <code>dnf install python3-openslide</code><br>
+        </div>
+        <div>
+          <i>Latest OpenSlide Python:</i><br>
+          <b><i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i></b><br>
+          <code>
+            dnf install dnf-plugins-core<br>
+            dnf copr enable <a href="https://copr.fedorainfracloud.org/coprs/g/openslide/openslide/">@openslide/openslide</a><br>
+            dnf install python3-openslide
+          </code>
+        </div>
       </td>
     </tr>
     <tr>
@@ -97,8 +121,34 @@ If you're looking for the bleeding edge,
     <tr>
       <th>Linux</th>
       <th><a href="https://fedoraproject.org/">Fedora</a></th>
-      <td><code>dnf install openslide-tools</code></td>
-      <td><code>dnf install python3-openslide</code></td>
+      <td>
+        <div>
+          <i>Official packages:</i><br>
+          <code>dnf install openslide-tools</code>
+        </div>
+        <div>
+          <i>Latest OpenSlide:</i><br>
+          <code>
+            dnf install dnf-plugins-core<br>
+            dnf copr enable <a href="https://copr.fedorainfracloud.org/coprs/g/openslide/openslide/">@openslide/openslide</a><br>
+            dnf install openslide-tools
+          </code>
+        </div>
+      </td>
+      <td>
+        <div>
+          <i>Official packages:</i><br>
+          <code>dnf install python3-openslide</code>
+        </div>
+        <div>
+          <i>Latest OpenSlide Python:</i><br>
+          <code>
+            dnf install dnf-plugins-core<br>
+            dnf copr enable <a href="https://copr.fedorainfracloud.org/coprs/g/openslide/openslide/">@openslide/openslide</a><br>
+            dnf install python3-openslide
+          </code>
+        </div>
+      </td>
     </tr>
     <tr>
       <th>Linux</th>

--- a/download/index.md
+++ b/download/index.md
@@ -75,7 +75,7 @@ If you're looking for the bleeding edge,
       </th>
       <td>
         <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>
-        <code>dnf install openslide</code><br>
+        <code>dnf install openslide-tools</code><br>
       </td>
       <td>
         <i>First, install <a href="https://fedoraproject.org/wiki/EPEL">EPEL</a>.</i><br>
@@ -97,7 +97,7 @@ If you're looking for the bleeding edge,
     <tr>
       <th>Linux</th>
       <th><a href="https://fedoraproject.org/">Fedora</a></th>
-      <td><code>dnf install openslide</code></td>
+      <td><code>dnf install openslide-tools</code></td>
       <td><code>dnf install python3-openslide</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
Document the new Copr.  Install the `openslide-tools` subpackage so we get the command-line tools as on other distros.  Use `dnf` because we no longer have a compatibility requirement for `yum`.