### PR TITLE
docs/testsuite: re-add valgrind command

### DIFF
--- a/docs/testsuite/index.md
+++ b/docs/testsuite/index.md
@@ -21,6 +21,11 @@ Sanitize mode requires:
 - clang
 - Debug symbols for library dependencies (particularly glib2) and Fontconfig
 
+Valgrind mode requires:
+
+- Valgrind
+- Debug symbols for library dependencies (particularly glib2) and Fontconfig
+
 Coverage mode requires:
 
 - gcov
@@ -42,6 +47,11 @@ undefined behavior, memory leaks, invalid memory accesses, double frees,
 etc., but is somewhat slow.
 
     ./driver sanitize
+
+You can also run the test cases under Valgrind.  This will catch memory
+leaks, invalid memory accesses, double frees, etc.  It is also very slow.
+
+    ./driver valgrind
 
 To generate a test coverage report:
 
@@ -65,8 +75,9 @@ the desired directory path.
 
 On some platforms, certain test cases may fail due to problems in other
 libraries.  To prevent those cases from cluttering the test report, you can
-set the `OPENSLIDE_TEST_XFAIL` environment variable to a comma-separated
-list of cases which are expected to fail.
+set the `OPENSLIDE_TEST_XFAIL` and/or `OPENSLIDE_VALGRIND_XFAIL` environment
+variables to a comma-separated list of cases which are expected to fail
+during `run` or `valgrind`, respectively.
 
 ### Using a local mirror
 


### PR DESCRIPTION
Partially reverts #75.  For https://github.com/openslide/openslide/pull/555.