### PR TITLE
synctiles: silence spurious warning with current flake8-bugbear

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     rev: v1.5.0
     hooks:
       - id: yesqa
+        additional_dependencies: [flake8-bugbear, Flake8-pyproject]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0

--- a/demo/_synctiles.py
+++ b/demo/_synctiles.py
@@ -309,7 +309,7 @@ class Tile:
                     ContentType=f'image/{FORMAT}',
                 )
             return self.key_name
-        except BaseException as e:
+        except BaseException as e:  # noqa: B036
             return e
 
     @classmethod


### PR DESCRIPTION
We aren't rethrowing the `BaseException` because we're returning it to a different thread instead.