### PR TITLE
Document `decoding` debug option, `tiff-log-callbacks` test feature flag

### DIFF
--- a/docs/debugopts/index.md
+++ b/docs/debugopts/index.md
@@ -2,10 +2,9 @@
 title: Debug Options
 ---
 
-Starting in OpenSlide 3.4.0, the `OPENSLIDE_DEBUG` environment variable can
-contain a comma-separated list of debug options that will affect the
-behavior of the library.  Pass `OPENSLIDE_DEBUG=help` for a list of debug
-options supported by your copy.
+The `OPENSLIDE_DEBUG` environment variable can contain a comma-separated
+list of debug options that will affect the behavior of the library.  Pass
+`OPENSLIDE_DEBUG=help` for a list of debug options supported by your copy.
 
 ### Options
 

--- a/docs/debugopts/index.md
+++ b/docs/debugopts/index.md
@@ -8,6 +8,9 @@ list of debug options that will affect the behavior of the library.  Pass
 
 ### Options
 
+`decoding`
+: Log non-fatal warnings emitted by format decoding libraries.
+
 `detection`
 : Log the error message returned by each format driver that does *not*
   detect support for the specified slide file during

--- a/docs/testsuite/index.md
+++ b/docs/testsuite/index.md
@@ -135,8 +135,11 @@ original slide (e.g., if OpenSlide falls back to `generic-tiff`), change
 `vendor` to the new string or `null` for NULL.
 
 If the test should only be run if particular OpenSlide dependencies are
-available, set `requires` to a list of feature flags.  Currently there are
-no defined feature flags.
+available, set `requires` to a list of feature flags.  Currently the
+supported feature flags are:
+
+> `tiff-log-callbacks`
+> : OpenSlide can capture warning/error log messages from libtiff
 
 Pack the test:
 


### PR DESCRIPTION
For https://github.com/openslide/openslide/pull/569.