### PR TITLE
synctiles: automatically detect number of available CPUs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         name: Modernize Python code
@@ -47,7 +47,7 @@ repos:
         additional_dependencies: [flake8-bugbear, Flake8-pyproject]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.0
+    rev: v1.13.0
     hooks:
       - id: mypy
         name: Check Python types

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Modernize Python code
-        args: ["--py312-plus"]
+        args: ["--py313-plus"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2

--- a/demo/_synctiles.py
+++ b/demo/_synctiles.py
@@ -30,6 +30,7 @@ from io import BytesIO
 import json
 from multiprocessing import Pool
 from multiprocessing.pool import Pool as PoolType
+import os
 from pathlib import Path, PurePath
 import re
 import sys
@@ -743,6 +744,8 @@ def finish_retile(ctxfile: TextIO, summarydir: Path) -> None:
 
 
 if __name__ == '__main__':
+    cpu_count = os.process_cpu_count()  # type: ignore[attr-defined]
+
     parser = ArgumentParser()
     subparsers = parser.add_subparsers(metavar='subcommand', required=True)
 
@@ -779,8 +782,8 @@ if __name__ == '__main__':
         metavar='COUNT',
         dest='workers',
         type=int,
-        default=4,
-        help='number of worker processes to start [4]',
+        default=cpu_count,
+        help=f'number of worker processes to start [{cpu_count}]',
     )
     parser_tile.set_defaults(cmd='tile')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 79
 skip-string-normalization = true
-target-version = ["py312"]
+target-version = ["py313"]
 
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 # requires Flake8-pyproject
@@ -14,4 +14,5 @@ force_sort_within_sections = true
 
 [tool.mypy]
 namespace_packages = false
+python_version = "3.13"
 strict = true


### PR DESCRIPTION
Requires Python 3.13+.