### PR TITLE
docs/devguide: update release checklist links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: '^(api/|demo/openseadragon-scalebar\.js)'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -15,7 +15,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.20.0
     hooks:
       - id: pyupgrade
         name: Modernize Python code
@@ -40,14 +40,14 @@ repos:
         additional_dependencies: [flake8-bugbear, Flake8-pyproject]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         name: Lint Python code with flake8
         additional_dependencies: [flake8-bugbear, Flake8-pyproject]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.17.1
     hooks:
       - id: mypy
         name: Check Python types

--- a/demo/_synctiles.py
+++ b/demo/_synctiles.py
@@ -104,8 +104,8 @@ SRGB_PROFILE: ImageCmsProfile = ImageCms.getOpenProfile(
 KeyMd5s = dict[PurePath, str]
 TestDataIndex = dict[str, 'TestDataSlide']
 
-dz_generators: dict[str | None, Generator]
-storage: S3Storage
+dz_generators: dict[str | None, Generator] = {}
+storage: S3Storage | None = None
 
 
 class TestDataSlide(TypedDict):
@@ -287,6 +287,7 @@ class Tile:
 
     def sync(self) -> PurePath | BaseException:
         """Generate and possibly upload a tile."""
+        assert storage is not None
         try:
             tile = dz_generators[self.associated].get_tile(
                 self.level, self.address

--- a/docs/devguide/index.md
+++ b/docs/devguide/index.md
@@ -113,11 +113,9 @@ advice.
 ## Release process
 
 We have issue templates for each type of release.  OpenSlide maintainers can
-perform a release by filing a new issue named after the new version to be
-released, and checking boxes.
+perform a release by filing a new issue and checking boxes.
 
-- [OpenSlide](https://github.com/openslide/openslide/issues/new?labels=release&template=release.md)
-- [OpenSlide Java](https://github.com/openslide/openslide-java/issues/new?labels=release&template=release.md)
-- [OpenSlide Python](https://github.com/openslide/openslide-python/issues/new?labels=release&template=release.md)
-  - [Updating for a Python major release](https://github.com/openslide/openslide-python/issues/new?labels=release&template=python-bump.md)
-- [openslide-bin](https://github.com/openslide/openslide-bin/issues/new?labels=release&template=release.md)
+- [OpenSlide](https://github.com/openslide/openslide/blob/main/.github/maintainer/README.md)
+- [OpenSlide Java](https://github.com/openslide/openslide-java/blob/main/.github/maintainer/README.md)
+- [OpenSlide Python](https://github.com/openslide/openslide-python/blob/main/.github/maintainer/README.md)
+- [openslide-bin](https://github.com/openslide/openslide-bin/blob/main/.github/maintainer/README.md)


### PR DESCRIPTION
GitHub removed the feature allowing Markdown issue templates without front matter to be used in the `template` query argument.  Our repos have switched to autogenerated Markdown documents with issue templates inlined into the links.