### PR TITLE
api: drop references/referenced-by lines in function descriptions

### DIFF
--- a/api/openslide_8h.html
+++ b/api/openslide_8h.html
@@ -463,10 +463,6 @@ Functions</h2></td></tr>
 <dl class="section return"><dt>Returns</dt><dd>A new cache. </dd></dl>
 <dl class="section since"><dt>Since</dt><dd>4.0.0 </dd></dl>
 
-<p class="reference">References <a class="el" href="#a611c06edc3173aa7f5fa60544a5b3a18">openslide_cache_create()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a611c06edc3173aa7f5fa60544a5b3a18">openslide_cache_create()</a>.</p>
-
 </div>
 </div>
 <a id="a870e374a309aaf96cbd36ba49c55ec8a" name="a870e374a309aaf96cbd36ba49c55ec8a"></a>
@@ -494,10 +490,6 @@ Functions</h2></td></tr>
 </dl>
 <dl class="section since"><dt>Since</dt><dd>4.0.0 </dd></dl>
 
-<p class="reference">References <a class="el" href="#a870e374a309aaf96cbd36ba49c55ec8a">openslide_cache_release()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a870e374a309aaf96cbd36ba49c55ec8a">openslide_cache_release()</a>.</p>
-
 </div>
 </div>
 <a id="a3a69dfe81462a4e90c8da78d1addc4bd" name="a3a69dfe81462a4e90c8da78d1addc4bd"></a>
@@ -523,10 +515,6 @@ Functions</h2></td></tr>
   </table>
   </dd>
 </dl>
-
-<p class="reference">References <a class="el" href="#a3a69dfe81462a4e90c8da78d1addc4bd">openslide_close()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a3a69dfe81462a4e90c8da78d1addc4bd">openslide_close()</a>.</p>
 
 </div>
 </div>
@@ -556,10 +544,6 @@ Functions</h2></td></tr>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>An identification of the format vendor for this file, or NULL. </dd></dl>
 <dl class="section since"><dt>Since</dt><dd>3.4.0 </dd></dl>
-
-<p class="reference">References <a class="el" href="#a213fb2cd919a61a13fe43bc38134854a">openslide_detect_vendor()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a213fb2cd919a61a13fe43bc38134854a">openslide_detect_vendor()</a>.</p>
 
 </div>
 </div>
@@ -604,10 +588,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 
-<p class="reference">References <a class="el" href="#a2d1bca93ff5cbd2e13c4e6aaec868fd1">openslide_get_associated_image_dimensions()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a2d1bca93ff5cbd2e13c4e6aaec868fd1">openslide_get_associated_image_dimensions()</a>.</p>
-
 </div>
 </div>
 <a id="a4a31de687aefba75055769fba6e80b35" name="a4a31de687aefba75055769fba6e80b35"></a>
@@ -639,10 +619,6 @@ Functions</h2></td></tr>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>-1 on error, 0 if no profile is available, otherwise the profile size in bytes. </dd></dl>
 
-<p class="reference">References <a class="el" href="#a4a31de687aefba75055769fba6e80b35">openslide_get_associated_image_icc_profile_size()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a4a31de687aefba75055769fba6e80b35">openslide_get_associated_image_icc_profile_size()</a>.</p>
-
 </div>
 </div>
 <a id="a0e1396ecc9104fa4993f35e80ddf8928" name="a0e1396ecc9104fa4993f35e80ddf8928"></a>
@@ -669,10 +645,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>A NULL-terminated string array of associated image names, or an empty array if an error occurred. </dd></dl>
-
-<p class="reference">References <a class="el" href="#a0e1396ecc9104fa4993f35e80ddf8928">openslide_get_associated_image_names()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a0e1396ecc9104fa4993f35e80ddf8928">openslide_get_associated_image_names()</a>.</p>
 
 </div>
 </div>
@@ -706,10 +678,6 @@ Functions</h2></td></tr>
 <dl class="section return"><dt>Returns</dt><dd>The level identifier, or -1 if an error occurred. </dd></dl>
 <dl class="section since"><dt>Since</dt><dd>3.3.0 </dd></dl>
 
-<p class="reference">References <a class="el" href="#ac8a91866597157a270b8f8434cb4d7fc">openslide_get_best_level_for_downsample()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#ac8a91866597157a270b8f8434cb4d7fc">openslide_get_best_level_for_downsample()</a>.</p>
-
 </div>
 </div>
 <a id="aa6600c795407ef09b27507e437c02e74" name="aa6600c795407ef09b27507e437c02e74"></a>
@@ -738,10 +706,6 @@ Functions</h2></td></tr>
 <dl class="section return"><dt>Returns</dt><dd>A string describing the original error that caused the problem, or NULL if no error has occurred. </dd></dl>
 <dl class="section since"><dt>Since</dt><dd>3.2.0 </dd></dl>
 
-<p class="reference">References <a class="el" href="#aa6600c795407ef09b27507e437c02e74">openslide_get_error()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#aa6600c795407ef09b27507e437c02e74">openslide_get_error()</a>.</p>
-
 </div>
 </div>
 <a id="a323af3836966ea1973d09b1a8ccf771f" name="a323af3836966ea1973d09b1a8ccf771f"></a>
@@ -767,10 +731,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>-1 on error, 0 if no profile is available, otherwise the profile size in bytes. </dd></dl>
-
-<p class="reference">References <a class="el" href="#a323af3836966ea1973d09b1a8ccf771f">openslide_get_icc_profile_size()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a323af3836966ea1973d09b1a8ccf771f">openslide_get_icc_profile_size()</a>.</p>
 
 </div>
 </div>
@@ -810,10 +770,6 @@ Functions</h2></td></tr>
 </dl>
 <dl class="section since"><dt>Since</dt><dd>3.3.0 </dd></dl>
 
-<p class="reference">References <a class="el" href="#ae075e78f69c4c443300fdcf36d019e82">openslide_get_level0_dimensions()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#ae075e78f69c4c443300fdcf36d019e82">openslide_get_level0_dimensions()</a>.</p>
-
 </div>
 </div>
 <a id="a19eedd09aef2bd65db7e3b0a44e54738" name="a19eedd09aef2bd65db7e3b0a44e54738"></a>
@@ -840,10 +796,6 @@ Functions</h2></td></tr>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>The number of levels, or -1 if an error occurred. </dd></dl>
 <dl class="section since"><dt>Since</dt><dd>3.3.0 </dd></dl>
-
-<p class="reference">References <a class="el" href="#a19eedd09aef2bd65db7e3b0a44e54738">openslide_get_level_count()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a19eedd09aef2bd65db7e3b0a44e54738">openslide_get_level_count()</a>.</p>
 
 </div>
 </div>
@@ -888,10 +840,6 @@ Functions</h2></td></tr>
 </dl>
 <dl class="section since"><dt>Since</dt><dd>3.3.0 </dd></dl>
 
-<p class="reference">References <a class="el" href="#a5c9c95c21b0657ea9965ddb4fab7eda8">openslide_get_level_dimensions()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a5c9c95c21b0657ea9965ddb4fab7eda8">openslide_get_level_dimensions()</a>.</p>
-
 </div>
 </div>
 <a id="a60daced5880dc3e4cf428dd81ba67bee" name="a60daced5880dc3e4cf428dd81ba67bee"></a>
@@ -924,10 +872,6 @@ Functions</h2></td></tr>
 <dl class="section return"><dt>Returns</dt><dd>The downsampling factor for this level, or -1.0 if an error occurred or the level was out of range. </dd></dl>
 <dl class="section since"><dt>Since</dt><dd>3.3.0 </dd></dl>
 
-<p class="reference">References <a class="el" href="#a60daced5880dc3e4cf428dd81ba67bee">openslide_get_level_downsample()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a60daced5880dc3e4cf428dd81ba67bee">openslide_get_level_downsample()</a>.</p>
-
 </div>
 </div>
 <a id="ae67443921b5bce769ec3dff5c3288b68" name="ae67443921b5bce769ec3dff5c3288b68"></a>
@@ -954,10 +898,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>A NULL-terminated string array of property names, or an empty array if an error occurred. </dd></dl>
-
-<p class="reference">References <a class="el" href="#ae67443921b5bce769ec3dff5c3288b68">openslide_get_property_names()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#ae67443921b5bce769ec3dff5c3288b68">openslide_get_property_names()</a>.</p>
 
 </div>
 </div>
@@ -991,10 +931,6 @@ Functions</h2></td></tr>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>The value of the named property, or NULL if the property doesn't exist or an error occurred. </dd></dl>
 
-<p class="reference">References <a class="el" href="#a23d3f612be44b5d6edce120e804539f4">openslide_get_property_value()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a23d3f612be44b5d6edce120e804539f4">openslide_get_property_value()</a>.</p>
-
 </div>
 </div>
 <a id="a0bf9b1f6eb8776873372e736e401661b" name="a0bf9b1f6eb8776873372e736e401661b"></a>
@@ -1015,10 +951,6 @@ Functions</h2></td></tr>
 <p>Get the version of the OpenSlide library. </p>
 <dl class="section return"><dt>Returns</dt><dd>A string describing the OpenSlide version. </dd></dl>
 <dl class="section since"><dt>Since</dt><dd>3.3.0 </dd></dl>
-
-<p class="reference">References <a class="el" href="#a0bf9b1f6eb8776873372e736e401661b">openslide_get_version()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a0bf9b1f6eb8776873372e736e401661b">openslide_get_version()</a>.</p>
 
 </div>
 </div>
@@ -1046,10 +978,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 <dl class="section return"><dt>Returns</dt><dd>On success, a new OpenSlide object. If the file is not recognized by OpenSlide, NULL. If the file is recognized but an error occurred, an OpenSlide object in error state. </dd></dl>
-
-<p class="reference">References <a class="el" href="#acb25a6142891aeb52a00d97ca07af7b8">openslide_open()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#acb25a6142891aeb52a00d97ca07af7b8">openslide_open()</a>.</p>
 
 </div>
 </div>
@@ -1091,10 +1019,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 
-<p class="reference">References <a class="el" href="#a71ace07f87c9aeab328d3a6efcd2f983">openslide_read_associated_image()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a71ace07f87c9aeab328d3a6efcd2f983">openslide_read_associated_image()</a>.</p>
-
 </div>
 </div>
 <a id="a26322f1638fb8c4c683a08ca1b5d3d4a" name="a26322f1638fb8c4c683a08ca1b5d3d4a"></a>
@@ -1133,10 +1057,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 
-<p class="reference">References <a class="el" href="#a26322f1638fb8c4c683a08ca1b5d3d4a">openslide_read_associated_image_icc_profile()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a26322f1638fb8c4c683a08ca1b5d3d4a">openslide_read_associated_image_icc_profile()</a>.</p>
-
 </div>
 </div>
 <a id="acaf491a585651d634735d0a61cf7fae2" name="acaf491a585651d634735d0a61cf7fae2"></a>
@@ -1168,10 +1088,6 @@ Functions</h2></td></tr>
   </table>
   </dd>
 </dl>
-
-<p class="reference">References <a class="el" href="#acaf491a585651d634735d0a61cf7fae2">openslide_read_icc_profile()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#acaf491a585651d634735d0a61cf7fae2">openslide_read_icc_profile()</a>.</p>
 
 </div>
 </div>
@@ -1236,10 +1152,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 
-<p class="reference">References <a class="el" href="#a0eeecec682efdf2ef18c8426109acad0">openslide_read_region()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a0eeecec682efdf2ef18c8426109acad0">openslide_read_region()</a>.</p>
-
 </div>
 </div>
 <a id="a15904ac24a0beb733f43667aab17b2a5" name="a15904ac24a0beb733f43667aab17b2a5"></a>
@@ -1270,10 +1182,6 @@ Functions</h2></td></tr>
   </dd>
 </dl>
 <dl class="section since"><dt>Since</dt><dd>4.0.0 </dd></dl>
-
-<p class="reference">References <a class="el" href="#a15904ac24a0beb733f43667aab17b2a5">openslide_set_cache()</a>.</p>
-
-<p class="reference">Referenced by <a class="el" href="#a15904ac24a0beb733f43667aab17b2a5">openslide_set_cache()</a>.</p>
 
 </div>
 </div>


### PR DESCRIPTION
They claim every function references and is referenced by itself, which is not useful.  Sync docs with openslide/openslide#756.

`sync-releases.py` is going to keep trying to revert this until after the next OpenSlide release.