### PR TITLE
demo: make a bitmap of blank tiles instead of uploading them

### DIFF
--- a/demo/_synctiles.py
+++ b/demo/_synctiles.py
@@ -3,7 +3,7 @@
 # _synctiles - Generate and upload Deep Zoom tiles for test slides
 #
 # Copyright (c) 2010-2015 Carnegie Mellon University
-# Copyright (c) 2016-2025 Benjamin Gilbert
+# Copyright (c) 2016-2026 Benjamin Gilbert
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of version 2.1 of the GNU Lesser General Public License
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 from argparse import ArgumentParser, FileType
+from array import array
 import base64
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -58,7 +59,7 @@ import requests
 if TYPE_CHECKING:
     from mypy_boto3_s3.service_resource import Object
 
-STAMP_VERSION = 'threads'  # change to retile without OpenSlide version bump
+STAMP_VERSION = 'sparse'  # change to retile without OpenSlide version bump
 CORS_ORIGINS = ['*']
 DOWNLOAD_BASE_URL = 'https://openslide.cs.cmu.edu/download/openslide-testdata/'
 DOWNLOAD_INDEX = 'index.json'
@@ -179,6 +180,12 @@ class ImageInfo(TypedDict):
     name: str | None
     mpp: float | None
     source: DzSource
+    sparse: dict[str, SparseLevel]
+
+
+class SparseLevel(TypedDict):
+    tiles: tuple[int, int]
+    bitmap: str
 
 
 class DzSource(TypedDict):
@@ -276,6 +283,30 @@ class S3Storage:
         )
 
 
+class SparseMap:
+    def __init__(self, generator: Generator):
+        self._level_tiles = generator.dz.level_tiles
+        self._bitmaps = [
+            # ceil division
+            array('B', [0] * -(level_tiles[0] * level_tiles[1] // -8))
+            for level_tiles in self._level_tiles
+        ]
+
+    def set_bit(self, level: int, address: tuple[int, int]) -> None:
+        bit = self._level_tiles[level][0] * address[1] + address[0]
+        self._bitmaps[level][bit >> 3] |= 1 << (bit & 7)
+
+    def save(self) -> dict[str, SparseLevel]:
+        return {
+            str(level): {
+                'tiles': self._level_tiles[level],
+                'bitmap': base64.b64encode(bitmap.tobytes()).decode(),
+            }
+            for level, bitmap in enumerate(self._bitmaps)
+            if any(bitmap)
+        }
+
+
 @dataclass
 class Tile:
     storage: S3Storage
@@ -285,9 +316,12 @@ class Tile:
     key_name: PurePath
     cur_md5: str | None
 
-    def sync(self) -> PurePath:
+    def sync(self) -> PurePath | tuple[int, tuple[int, int]]:
         """Generate and possibly upload a tile."""
         tile = self.generator.get_tile(self.level, self.address)
+        if tile.getextrema() == ((255, 255), (255, 255), (255, 255)):  # type: ignore[no-untyped-call]
+            # completely white tile; add to sparse bitmap
+            return (self.level, self.address)
         buf = BytesIO()
         tile.save(
             buf,
@@ -358,13 +392,18 @@ def sync_image(
 
     # Sync tiles
     progress()
+    sparse_map = SparseMap(generator)
     for future in as_completed(
         exec.submit(Tile.sync, tile)
         for tile in Tile.enumerate(
             storage, generator, key_imagepath, key_md5sums
         )
     ):
-        key_md5sums.pop(future.result(), None)
+        result = future.result()
+        if isinstance(result, PurePath):
+            key_md5sums.pop(result, None)
+        else:
+            sparse_map.set_bit(*result)
         count += 1
         if count % 100 == 0:
             progress()
@@ -391,6 +430,7 @@ def sync_image(
         'name': associated,
         'mpp': mpp,
         'source': source,
+        'sparse': sparse_map.save(),
     }
 
 

--- a/demo/_synctiles.py
+++ b/demo/_synctiles.py
@@ -25,6 +25,7 @@ import base64
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+import gzip
 from hashlib import md5, sha256
 from io import BytesIO
 import json
@@ -262,10 +263,15 @@ class S3Storage:
         self, path: PurePath, item: Any, cache: bool = True
     ) -> None:
         self.object(path).put(
-            Body=json.dumps(item, indent=1, sort_keys=True).encode(),
+            Body=gzip.compress(
+                json.dumps(
+                    item, separators=(',', ':'), sort_keys=True
+                ).encode()
+            ),
             CacheControl=(
                 CACHE_CONTROL_CACHE if cache else CACHE_CONTROL_NOCACHE
             ),
+            ContentEncoding='gzip',
             ContentType='application/json',
         )
 
@@ -403,8 +409,11 @@ def sync_slide(
 
     # Get current metadata
     try:
+        resp = storage.object(metadata_key_name).get()
         metadata: SlideMetadata | None = json.load(
-            storage.object(metadata_key_name).get()['Body']
+            gzip.open(resp['Body'])
+            if resp.get('ContentEncoding') == 'gzip'
+            else resp['Body']
         )
     except storage.NoSuchKey:
         metadata = None
@@ -629,8 +638,12 @@ def start_retile(
 
     # If the stamp is changing, mark bucket dirty
     try:
-        stream = storage.object(PurePath(METADATA_NAME)).get()['Body']
-        metadata: BucketMetadata = json.load(stream)
+        resp = storage.object(PurePath(METADATA_NAME)).get()
+        metadata: BucketMetadata = json.load(
+            gzip.open(resp['Body'])
+            if resp.get('ContentEncoding') == 'gzip'
+            else resp['Body']
+        )
         old_stamp = metadata['stamp']
     except storage.NoSuchKey:
         old_stamp = None

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,7 @@
   OpenSlide demo site
 
   Copyright (c) 2010-2015 Carnegie Mellon University
-  Copyright (c) 2016 Benjamin Gilbert
+  Copyright (c) 2016-2026 Benjamin Gilbert
 
   This program is free software; you can redistribute it and/or modify it
   under the terms of version 2.1 of the GNU Lesser General Public License
@@ -70,6 +70,7 @@ $(function() {
     var stamp;
     var groups;
     var viewer;
+    var image;
     var status_skipped;
 
     function check_status() {
@@ -114,6 +115,22 @@ $(function() {
     });
     setInterval(check_status, 300000);
 
+    function decode_sparse_bitmaps(image) {
+        $.each(image.sparse, function(level, sparse) {
+            if (Uint8Array.fromBase64) {
+                sparse.bitmap = Uint8Array.fromBase64(sparse.bitmap, {
+                    lastChunkHandling: "strict"
+                });
+            } else {
+                var decoded = atob(sparse.bitmap);
+                sparse.bitmap = new Uint8Array(decoded.length);
+                for (var i = 0; i < decoded.length; i++) {
+                    sparse.bitmap[i] = decoded.charCodeAt(i);
+                }
+            }
+        });
+    }
+
     function populate_images(data, status, xhr) {
         stamp = data.stamp;
         groups = data.groups;
@@ -140,7 +157,9 @@ $(function() {
                     a.data('slide', j);
                     a.data('image', k);
                     $('<li/>').appendTo(images).append(a);
+                    decode_sparse_bitmaps(image);
                 });
+                decode_sparse_bitmaps(slide.slide);
             });
         });
         var versions = $('<p id="versions">');
@@ -201,7 +220,6 @@ $(function() {
         var slide_id = link.data('slide');
         var associated_id = link.data('image');
         var slide = groups[group_id].slides[slide_id];
-        var image;
         if (typeof associated_id === 'undefined') {
             image = slide.slide;
         } else {
@@ -253,6 +271,28 @@ $(function() {
                 var getTileUrl = viewer.source.getTileUrl;
                 viewer.source.getTileUrl = function() {
                     return getTileUrl.apply(this, arguments) + '?v=' + stamp;
+                };
+                var tileExists = viewer.source.tileExists;
+                viewer.source.tileExists = function(level, x, y) {
+                    if (!tileExists.apply(this, arguments)) {
+                        return false;
+                    }
+                    if (!image.sparse) {
+                        return true;
+                    }
+                    var sparse = image.sparse[level];
+                    if (!sparse) {
+                        return true;
+                    }
+                    if (x < 0 || y < 0 ||
+                        x >= sparse.tiles[0] || y >= sparse.tiles[1]) {
+                        return false;
+                    }
+                    var idx = y * sparse.tiles[0] + x;
+                    if (sparse.bitmap[idx >> 3] & (1 << (idx & 7))) {
+                        return false;
+                    }
+                    return true;
                 };
             });
             viewer.scalebar({

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,7 +59,7 @@
     <div id="details" class="scroll-parent"></div>
 </div>
 
-<script src="https://code.jquery.com/jquery-4.0.0.min.js" integrity="sha256-OaVG6prZf4v69dPg6PhVattBXkcOWQB62pdZ3ORyrao=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@4.0.0/dist/jquery.min.js" integrity="sha256-OaVG6prZf4v69dPg6PhVattBXkcOWQB62pdZ3ORyrao=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/openseadragon@6.0.2/build/openseadragon/openseadragon.min.js" integrity="sha256-xFw3UC7oKMnWjRwWFCtFNv5UgUx1xnqzFw8aCVkn7UY=" crossorigin="anonymous"></script>
 <script src="openseadragon-scalebar.js"></script>
 <script>


### PR DESCRIPTION
When tiling, don't upload completely white tiles; add them to a bitmap instead.  If the bitmap is non-empty, Base64-encode it and add it to `info.json`.  Then, if a bit is set, tell OpenSeadragon the tile doesn't exist so OSD won't fetch it, using pixels from the next lower resolution instead.

We can't simply omit blank tiles because OSD unavoidably logs a console message for every fetch failure.  Using the bitmap also saves a round trip.

To counter the increase in JSON sizes, gzip JSON objects in the S3 bucket.  S3 can't negotiate Content-Encoding, but we can precompress objects and unconditionally set the `Content-Encoding` header.  This works for browsers, which always set `Accept-Encoding: gzip`, but causes problems for `curl` (without `--compressed`) and Python `requests` etc.  However, our JSON is really only intended for browsers (and for `synctiles` itself).