### PR TITLE
Minify site during deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,14 +21,22 @@ concurrency:
 jobs:
   build:
     name: Build site
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install minify
       - name: Check out repo
         uses: actions/checkout@v7
       - name: Set up Pages
         uses: actions/configure-pages@v6
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
+      - name: Minify
+        run: |
+          sudo chown -R $USER:$USER _site
+          minify -ri _site --exclude '_site/api/**'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
 


### PR DESCRIPTION
The files served by the website are not source code; the source is in the Git repo.  Now that we have a customizable deployment workflow, minify the HTML, CSS, and JS before publishing.

Don't minify generated API documentation to avoid having to debug any resulting problems.

Switch build runner to Ubuntu 26.04 to get a newer version of `minify`.