### PR TITLE
Update to Jekyll 4.4; allow Sphinx underscore directories; fix deployment in forks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,16 +26,15 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install minify
+          sudo apt-get -y install jekyll minify ruby-jekyll-redirect-from
       - name: Check out repo
         uses: actions/checkout@v7
       - name: Set up Pages
+        id: pages
         uses: actions/configure-pages@v6
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-      - name: Minify
+      - name: Build
         run: |
-          sudo chown -R $USER:$USER _site
+          jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
           minify -ri _site --exclude '_site/api/**'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/_config.yml
+++ b/_config.yml
@@ -7,5 +7,5 @@ defaults:
 exclude:
   - pyproject.toml
 
-gems:
+plugins:
   - jekyll-redirect-from

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,12 @@ defaults:
     values:
       layout: default
 
+include:
+  # should be 'api/python/_*'
+  # https://github.com/jekyll/jekyll/issues/9116
+  - _sources
+  - _static
+
 exclude:
   - pyproject.toml
 

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,46 +1,46 @@
-[news]: /news/
-[download]: /download/
-[download-bin]: /download/#binaries
+[news]: {{ site.baseurl }}/news/
+[download]: {{ site.baseurl }}/download/
+[download-bin]: {{ site.baseurl }}/download/#binaries
 [download-copr]: https://copr.fedorainfracloud.org/coprs/g/openslide/openslide/
 [download-ppa]: https://launchpad.net/~openslide/+archive/ubuntu/openslide
 [download-pypi]: https://pypi.org/project/openslide-python/#files
-[license]: /license/
-[demo]: /demo/
-[other-projects]: /other-projects/
+[license]: {{ site.baseurl }}/license/
+[demo]: {{ site.baseurl }}/demo/
+[other-projects]: {{ site.baseurl }}/other-projects/
 [github]: https://github.com/openslide
 [wiki]: https://github.com/openslide/openslide/wiki
 [testdata]: https://openslide.cs.cmu.edu/download/openslide-testdata/
-[snapshots]: /builds/
-[submit-sample]: /submit/
+[snapshots]: {{ site.baseurl }}/builds/
+[submit-sample]: {{ site.baseurl }}/submit/
 
-[doc-dev]: /#development
-[doc-debugopts]: /docs/debugopts/
-[doc-devguide]: /docs/devguide/
-[doc-newformat]: /docs/newformat/
-[doc-premultiplied]: /docs/premultiplied-argb/
-[doc-properties]: /docs/properties/
-[doc-signoff]: /docs/signoff/
-[doc-testsuite]: /docs/testsuite/
-[doc-windows]: /docs/windows/
+[doc-dev]: {{ site.baseurl }}/#development
+[doc-debugopts]: {{ site.baseurl }}/docs/debugopts/
+[doc-devguide]: {{ site.baseurl }}/docs/devguide/
+[doc-newformat]: {{ site.baseurl }}/docs/newformat/
+[doc-premultiplied]: {{ site.baseurl }}/docs/premultiplied-argb/
+[doc-properties]: {{ site.baseurl }}/docs/properties/
+[doc-signoff]: {{ site.baseurl }}/docs/signoff/
+[doc-testsuite]: {{ site.baseurl }}/docs/testsuite/
+[doc-windows]: {{ site.baseurl }}/docs/windows/
 [gerror-rules]: https://docs.gtk.org/glib/error-reporting.html#rules-for-use-of-gerror
 
-[c-api]: /api/openslide_8h.html
-[python-api]: /api/python/
+[c-api]: {{ site.baseurl }}/api/openslide_8h.html
+[python-api]: {{ site.baseurl }}/api/python/
 
-[formats]: /formats/
-[format-aperio]: /formats/aperio/
-[format-argos]: /formats/argos/
-[format-dicom]: /formats/dicom/
-[format-generic-tiff]: /formats/generic-tiff/
-[format-hamamatsu]: /formats/hamamatsu/
-[format-huron]: /formats/huron/
-[format-leica]: /formats/leica/
-[format-mirax]: /formats/mirax/
-[format-philips]: /formats/philips/
-[format-sakura]: /formats/sakura/
-[format-trestle]: /formats/trestle/
-[format-ventana]: /formats/ventana/
-[format-zeiss]: /formats/zeiss/
+[formats]: {{ site.baseurl }}/formats/
+[format-aperio]: {{ site.baseurl }}/formats/aperio/
+[format-argos]: {{ site.baseurl }}/formats/argos/
+[format-dicom]: {{ site.baseurl }}/formats/dicom/
+[format-generic-tiff]: {{ site.baseurl }}/formats/generic-tiff/
+[format-hamamatsu]: {{ site.baseurl }}/formats/hamamatsu/
+[format-huron]: {{ site.baseurl }}/formats/huron/
+[format-leica]: {{ site.baseurl }}/formats/leica/
+[format-mirax]: {{ site.baseurl }}/formats/mirax/
+[format-philips]: {{ site.baseurl }}/formats/philips/
+[format-sakura]: {{ site.baseurl }}/formats/sakura/
+[format-trestle]: {{ site.baseurl }}/formats/trestle/
+[format-ventana]: {{ site.baseurl }}/formats/ventana/
+[format-zeiss]: {{ site.baseurl }}/formats/zeiss/
 
 [announce-subscribe]: https://lists.andrew.cmu.edu/mailman/listinfo/openslide-announce/
 [users-subscribe]: https://lists.andrew.cmu.edu/mailman/listinfo/openslide-users/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,15 +4,15 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="google-site-verification" content="yvwMK1VpVw3S23cQzeGtY6P89umLCY5RD04QI4gAUj0"/>
 <title>{{ page.title }}</title>
-<link rel="stylesheet" href="/css/trac.css" type="text/css"/>
-<link rel="stylesheet" href="/css/newsflash.css" type="text/css"/>
-<link rel="stylesheet" href="/css/custom.css" type="text/css"/>
+<link rel="stylesheet" href="{{ site.baseurl }}/css/trac.css" type="text/css"/>
+<link rel="stylesheet" href="{{ site.baseurl }}/css/newsflash.css" type="text/css"/>
+<link rel="stylesheet" href="{{ site.baseurl }}/css/custom.css" type="text/css"/>
 </head>
 
 <body class="{{ page.classes }}">
 
 <div id="header">
-<a href="/"><img src="/images/openslide_logo.png" alt="OpenSlide" width="306" height="102"></a>
+<a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/images/openslide_logo.png" alt="OpenSlide" width="306" height="102"></a>
 <div class="searchbox">
 <div class="inner">
 <gcse:searchbox-only></gcse:searchbox-only>

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,8 +27,8 @@
 
 <body>
 <div id="header">
-    <a href="/">
-        <img src="/images/openslide_logo.png" height="102" width="306">
+    <a href="..">
+        <img src="../images/openslide_logo.png" height="102" width="306">
     </a>
     <div id="help-text">
         <p class="no-top">These are example slides scanned on a variety of

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ extra_credits:
 {% include links.md %}
 
 <a href="https://github.com/openslide">
-  <img class="forkme-ribbon" src="/images/fork-me.png" alt="Fork me on GitHub">
+  <img class="forkme-ribbon" src="{{ site.baseurl }}/images/fork-me.png" alt="Fork me on GitHub">
 </a>
 
 <div markdown="1" class="newsflash">

--- a/search/index.html
+++ b/search/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <title>Search Results</title>
-<link rel="stylesheet" href="/css/trac.css" type="text/css"/>
-<link rel="stylesheet" href="/css/custom.css" type="text/css"/>
+<link rel="stylesheet" href="../css/trac.css" type="text/css"/>
+<link rel="stylesheet" href="../css/custom.css" type="text/css"/>
 <style type="text/css">
 table {
   border: 0;
@@ -34,7 +34,7 @@ div.results .gs-per-result-labels {
 <body>
 
 <div id="header">
-<a href="/"><img class="openslide-logo" src="/images/openslide_logo.png" alt="OpenSlide" width="306" height="102"></a>
+<a href=".."><img class="openslide-logo" src="../images/openslide_logo.png" alt="OpenSlide" width="306" height="102"></a>
 <div class="searchbox">
 <div class="inner">
 <gcse:searchbox-only></gcse:searchbox-only>


### PR DESCRIPTION
`actions/jekyll-build-pages` is pinned to Jekyll 3.  Use the Jekyll package from Ubuntu 26.04.

Allow OpenSlide Python to stop renaming Sphinx's `_static` and `_sources` directories during docs build.

When the site is deployed in a fork for testing, it won't be at the root of the domain.  Properly prefix URLs with the site root.